### PR TITLE
Init on reconnecting ws

### DIFF
--- a/src/WS/WScontroller.ts
+++ b/src/WS/WScontroller.ts
@@ -26,7 +26,7 @@ let FLAGwsReconnect = false;
 
 export const initWS = async () => {
   //既に接続済みの場合は再接続しない
-  if (ws === undefined) {
+  if (ws === undefined || ws.readyState === WebSocket.CLOSED) {
     ws = new WebSocket("/ws");
   }
 


### PR DESCRIPTION
現在ブラウザ側でWSを完全に断ち切る状況を再現できないため初期処理再実行は未確認。